### PR TITLE
feat: parallel implementation (Cursed Seal Mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ skels = kimimaro.skeletonize(
   fix_branching=True, # default True
   fix_borders=True, # default True
   progress=True, # default False
+  parallel=1, # <= 0 all cpu, 1 single process, 2+ multiprocess
 )
 ```
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -1,9 +1,7 @@
 import pytest
 
 import numpy as np
-
 from cloudvolume import *
-import edt
 
 import kimimaro
 
@@ -142,4 +140,41 @@ def test_fix_borders_y():
   assert np.all(skel.vertices[:,0] == 129)
   assert np.all(skel.vertices[:,1] == np.arange(256))
   assert np.all(skel.vertices[:,2] == 129)
+
+def test_parallel():
+  labels = np.zeros((256, 256, 128), dtype=np.uint8)
+  labels[ 0:128, 0:128, : ] = 1
+  labels[ 0:128, 128:256, : ] = 2
+  labels[ 128:256, 0:128, : ] = 3
+  labels[ 128:256, 128:256, : ] = 4
+
+  skels = kimimaro.skeletonize(
+    labels,
+    teasar_params={
+      'const': 250,
+      'scale': 10,
+      'pdrf_exponent': 4,
+      'pdrf_scale': 100000,
+    }, 
+    anisotropy=(1,1,1),
+    object_ids=None, 
+    dust_threshold=1000, 
+    cc_safety_factor=1,
+    progress=True, 
+    fix_branching=True, 
+    in_place=False, 
+    fix_borders=True,
+    parallel=2,
+  )
+
+  assert len(skels) == 4
+
+
+
+
+
+
+
+
+
   

--- a/automated_test.py
+++ b/automated_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+import edt
 import numpy as np
 from cloudvolume import *
 

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -94,6 +94,10 @@ def skeletonize(
     fix_borders: ensure that segments touching the border place a 
       skeleton endpoint in a predictable place to make merging 
       adjacent chunks easier.
+    parallel: number of subprocesses to use.
+      <= 0: Use multiprocessing.count_cpu() 
+         1: Only use the main process.
+      >= 2: Use this number of subprocesses.
 
   Returns: { $segid: cloudvolume.PrecomputedSkeleton, ... }
   """

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -141,6 +141,8 @@ def skeletonize(
   if fix_borders:
     border_targets = compute_border_targets(cc_labels)
 
+  print_quotes(parallel) # easter egg
+
   if parallel <= 0:
     parallel = mp.cpu_count()
 
@@ -355,3 +357,12 @@ def merge(skeletons):
     merged_skels[segid] = skel.consolidate()
 
   return merged_skels
+
+def print_quotes(parallel):
+  if parallel == -1:
+    print("Against the power of will I possess... The capability of my body is nothing.")
+  elif parallel == -2:
+    print("I will see the truth of this world... OROCHIMARU-SAMA WILL SHOW ME!!!")
+
+  if -2 <= parallel < 0:
+    print("CURSED SEAL OF THE EARTH!!!")  

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -152,8 +152,9 @@ def skeletonize(
     del cc_labels
     
     skeletonizefn = partial(parallel_skeletonize_subset, 
-      dbf_shm_location, cc_shm_location, remapping, 
-      teasar_params, anisotropy, all_slices, 
+      dbf_shm_location, all_dbf_shm.shape, all_dbf_shm.dtype, 
+      cc_shm_location, cc_labels_shm.shape, cc_labels_shm.dtype,
+      remapping, teasar_params, anisotropy, all_slices, 
       border_targets, progress, fix_borders, fix_branching
     )
 
@@ -175,11 +176,12 @@ def skeletonize(
     return merge(skeletons)
 
 def parallel_skeletonize_subset(    
-    dbf_shm_location, cc_shm_location, *args, **kwargs
+    dbf_shm_location, dbf_shape, dbf_dtype, 
+    cc_shm_location, cc_shape, cc_dtype, *args, **kwargs
   ):
   
-  dbf_mmap, all_dbf = shm.ndarray( (512,512,512), dtype=np.float32, location=dbf_shm_location, order='F')
-  cc_mmap, cc_labels = shm.ndarray( (512,512,512), dtype=np.uint32, location=cc_shm_location, order='F')
+  dbf_mmap, all_dbf = shm.ndarray( dbf_shape, dtype=dbf_dtype, location=dbf_shm_location, order='F')
+  cc_mmap, cc_labels = shm.ndarray( cc_shape, dtype=cc_dtype, location=cc_shm_location, order='F')
 
   skels = skeletonize_subset(all_dbf, cc_labels, *args, **kwargs)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ dijkstra3d
 edt>=1.2.3
 fastremap>=1.5.0
 numpy>=1.16.1
+pathos
 pytest
 scipy>=1.1.0


### PR DESCRIPTION
Single volume parallel is hugely powerful. On an n1-standard-16, you can for example do sixteen 512^3  tasks using multiprocessing. However, each task has limited context (which is why we have the fix_borders flag). This is problematic for large structures like somata. What if instead of doing 16 tasks apart, we fuse their memory together into a 16x bigger volume? This results in cube_root(16) = 2.5x more context along each axial dimension. In our case, that means moving from 16.3 microns to 40.9 microns which is the difference between barely fitting a soma to comfortably fitting a soma.  

The main downside is the Preamble is still single threaded, so doing this increases task latency. However, the actual skeletonization will proceed in parallel. 

Hence, because Kimimaro will fight one to two orders of magnitude bigger and faster, this might be considered its cursed seal mode.

Addresses #3

![image](https://user-images.githubusercontent.com/2517065/56769266-b57e3c00-677e-11e9-9b91-adbafd298100.png)