### PR TITLE
feat: specify extra_targets_before and after

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ skels = kimimaro.skeletonize(
     'max_paths': 50, # default None
   },
   # object_ids=[ ... ], # process only the specified labels
+  # extra_targets_before=[ (27,33,100), (44,45,46) ], # target points in voxels
+  # extra_targets_after=[ (27,33,100), (44,45,46) ], # target points in voxels
   dust_threshold=1000, # skip connected components with fewer than this many voxels
   anisotropy=(16,16,40), # default True
   fix_branching=True, # default True
@@ -108,6 +110,14 @@ Represents the physical dimension of each voxel. For example, a connectomics dat
 #### `dust_threshold`
 
 This threshold culls connected components that are smaller than this many voxels.  
+
+### `extra_targets_after`
+
+Additional voxel targets to trace to after the morphological tracing algorithm completes. For example, you might add known synapse locations to the skeleton. 
+
+### `extra_targets_before`  
+
+This is the same as `extra_targets_after` except that the additional targets are front-loaded and the paths that they cover are invalidated. This may affect the results of subsequent morphological tracing.
 
 #### `max_paths`  
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -154,6 +154,40 @@ def test_fix_borders_y():
   assert np.all(skel.vertices[:,1] == np.arange(256))
   assert np.all(skel.vertices[:,2] == 129)
 
+def test_extra_targets():
+  labels = np.zeros((256, 256, 1), dtype=np.uint8)
+  labels[ 64:196, 64:196, : ] = 128
+
+  def skeletonize(labels, **kwargs):
+    return kimimaro.skeletonize(
+      labels,
+      teasar_params={
+        'const': 250,
+        'scale': 10,
+        'pdrf_exponent': 4,
+        'pdrf_scale': 100000,
+      }, 
+      anisotropy=(1,1,1),
+      object_ids=None, 
+      dust_threshold=1000, 
+      cc_safety_factor=1,
+      progress=True, 
+      fix_branching=True, 
+      in_place=False, 
+      fix_borders=True,
+      **kwargs
+    )[128]
+
+  skel1 = skeletonize(labels)
+  skel2 = skeletonize(labels, extra_targets_after=[ (65, 65, 0) ])
+
+  assert skel1.vertices.size < skel2.vertices.size
+
+  skel3 = skeletonize(labels, extra_targets_before=[ (65, 65, 0) ])
+
+  assert skel3.vertices.size < skel2.vertices.size
+
+
 def test_parallel():
   labels = np.zeros((256, 256, 128), dtype=np.uint8)
   labels[ 0:128, 0:128, : ] = 1

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -52,7 +52,7 @@ def skeletonize(
     object_ids=None, dust_threshold=1000, cc_safety_factor=1,
     progress=False, fix_branching=True, in_place=False, 
     fix_borders=True, parallel=1, parallel_chunk_size=100,
-    extra_targets=[],
+    extra_targets_before=[], extra_targets_after=[],
   ):
   """
   Skeletonize all non-zero labels in a given 2D or 3D image.
@@ -84,11 +84,16 @@ def skeletonize(
       disjoint set maps in connected_components. 1 is guaranteed to work,
       but is probably excessive and corresponds to every pixel being a different
       label. Use smaller values to save some memory.
-    extra_targets: List of x,y,z voxel coordinates that will all be traced 
-      to from the root regardless of whether those points have been invalidated. 
-      If a point lies outside the shape, it will be ignored.
 
-      e.g. { SEGID: [ (x,y,z), (x,y,z), ... ] }
+    extra_targets_before: List of x,y,z voxel coordinates that will all 
+      be traced to from the root regardless of whether those points have 
+      been invalidated. These targets will be applied BEFORE the regular
+      target selection algorithm is run.      
+
+      e.g. [ (x,y,z), (x,y,z) ]
+
+    extra_targets_after: Same as extra_targets_before but the additional
+      targets will be applied AFTER the usual algorithm runs.
 
     progress: if true, display a progress bar
     fix_branching: When enabled, zero the edge weights by of previously 
@@ -128,7 +133,8 @@ def skeletonize(
   cc_labels, remapping = compute_cc_labels(all_labels, cc_safety_factor)
   del all_labels
 
-  extra_targets = points_to_labels(extra_targets, cc_labels)
+  extra_targets_before = points_to_labels(extra_targets_before, cc_labels)
+  extra_targets_after = points_to_labels(extra_targets_after, cc_labels)
 
   all_dbf = edt.edt(cc_labels, 
     anisotropy=anisotropy,
@@ -159,7 +165,7 @@ def skeletonize(
     return skeletonize_subset(
       all_dbf, cc_labels, remapping, 
       teasar_params, anisotropy, all_slices, 
-      border_targets, extra_targets,
+      border_targets, extra_targets_before, extra_targets_after,
       progress, fix_borders, fix_branching, 
       cc_segids
     )
@@ -183,7 +189,7 @@ def skeletonize(
       all_dbf_shm, dbf_shm_location, 
       cc_labels_shm, cc_shm_location, remapping, 
       teasar_params, anisotropy, all_slices, 
-      border_targets, extra_targets,
+      border_targets, extra_targets_before, extra_targets_after,
       progress, fix_borders, fix_branching, 
       cc_segids, parallel, parallel_chunk_size
     )
@@ -235,7 +241,7 @@ def skeletonize_parallel(
     all_dbf_shm, dbf_shm_location, 
     cc_labels_shm, cc_shm_location, remapping, 
     teasar_params, anisotropy, all_slices, 
-    border_targets, extra_targets,
+    border_targets, extra_targets_before, extra_targets_after,
     progress, fix_borders, fix_branching, 
     cc_segids, parallel, chunk_size
   ):
@@ -256,8 +262,8 @@ def skeletonize_parallel(
       dbf_shm_location, all_dbf_shm.shape, all_dbf_shm.dtype, 
       cc_shm_location, cc_labels_shm.shape, cc_labels_shm.dtype,
       remapping, teasar_params, anisotropy, all_slices, 
-      border_targets, extra_targets, progress, 
-      fix_borders, fix_branching
+      border_targets, extra_targets_before, extra_targets_after, 
+      progress, fix_borders, fix_branching
     )
 
     ccids = []
@@ -303,7 +309,7 @@ def parallel_skeletonize_subset(
 def skeletonize_subset(
     all_dbf, cc_labels, remapping, 
     teasar_params, anisotropy, all_slices, 
-    border_targets, extra_targets,
+    border_targets, extra_targets_before, extra_targets_after,
     progress, fix_borders, fix_branching,
     cc_segids
   ):
@@ -323,7 +329,8 @@ def skeletonize_subset(
     labels = (labels == segid)
     dbf = (labels * all_dbf[slices]).astype(np.float32)
 
-    manual_targets = []
+    manual_targets_before = []
+    manual_targets_after = []
     root = None 
 
     def translate_to_roi(targets):
@@ -338,18 +345,22 @@ def skeletonize_subset(
     # anywhere within the shape or off the shape, making it 
     # a dicey proposition. 
     if len(border_targets[segid]) > 0:
-      manual_targets = translate_to_roi(border_targets[segid])
-      root = manual_targets.pop()
+      manual_targets_before = translate_to_roi(border_targets[segid])
+      root = manual_targets_before.pop()
 
-    if segid in extra_targets and len(extra_targets[segid]) > 0:
-      manual_targets.extend( translate_to_roi(extra_targets[segid]) )
+    if segid in extra_targets_before and len(extra_targets_before[segid]) > 0:
+      manual_targets_before.extend( translate_to_roi(extra_targets_before[segid]) )
+
+    if segid in extra_targets_after and len(extra_targets_after[segid]) > 0:
+      manual_targets_after.extend( translate_to_roi(extra_targets_after[segid]) )
 
     skeleton = kimimaro.trace.trace(
       labels, 
       dbf, 
       anisotropy=anisotropy, 
       fix_branching=fix_branching, 
-      manual_targets=manual_targets,
+      manual_targets_before=manual_targets_before,
+      manual_targets_after=manual_targets_after,
       root=root,
       **teasar_params
     )

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -326,6 +326,11 @@ def skeletonize_subset(
     manual_targets = []
     root = None 
 
+    def translate_to_roi(targets):
+      targets = np.array(targets)
+      targets -= roi.minpt.astype(np.uint32)
+      return targets.tolist()      
+
     # We only source a predetermined root from 
     # border_targets because we understand that it's
     # located at a reasonable place at the edge of the
@@ -333,13 +338,11 @@ def skeletonize_subset(
     # anywhere within the shape or off the shape, making it 
     # a dicey proposition. 
     if len(border_targets[segid]) > 0:
-      manual_targets = np.array(border_targets[segid])
-      manual_targets -= roi.minpt.astype(np.uint32)
-      manual_targets = manual_targets.tolist()
+      manual_targets = translate_to_roi(border_targets[segid])
       root = manual_targets.pop()
 
     if segid in extra_targets and len(extra_targets[segid]) > 0:
-      manual_targets.extend(extra_targets[segid])
+      manual_targets.extend( translate_to_roi(extra_targets[segid]) )
 
     skeleton = kimimaro.trace.trace(
       labels, 

--- a/kimimaro/trace.py
+++ b/kimimaro/trace.py
@@ -106,14 +106,15 @@ def trace(
     dbf_max = np.max(DBF) 
     soma_mode = dbf_max > soma_acceptance_threshold
 
+  soma_radius = 0.0
+
   if root is None:
     if soma_mode:
       root = find_soma_root(DBF, dbf_max)    
       soma_radius = dbf_max * soma_invalidation_scale + soma_invalidation_const
     else:
       root = find_root(labels, anisotropy)
-      soma_radius = 0.0
-
+      
   if root is None:
     return PrecomputedSkeleton()
  


### PR DESCRIPTION
feat: specify root for core skeletonization routine

This allows an end user to specify e.g. the location of
synapses in a neuron to ensure we trace to them. Note that
unlike border_targets, extra_targets do not have an effect
on what the root node will be. This is because they are totally
uncontrolled and can be located off of the shape.

Resolves #17 