### PR TITLE
feat: add fill_holes argument

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
+Jingpeng Wu <jingpeng.wu@gmail.com>
 William Silversmith <william.silversmith@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,14 @@
 CHANGES
 =======
 
-1.4.0
+1.4.2
+-----
+
+* chore: loosen networkx requirement (#49)
+* Update README.md
+* docs: update memory usage diagram for version 1.4.0
+
+1.4.1
 -----
 
 * perf: switch source and target for dijkstra

--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ You'll probably never want to disable this, but base TEASAR is infamous for fork
 
 #### `fill_holes`
 
-If your segmentation contains artifacts that cause holes to appear in labels, you can preprocess the entire image to eliminate background holes and holes caused by entirely contained inclusions. This option adds a moderate amount of additional processing time at the beginning (perhaps ~30%).
+THIS WILL REMOVE INPUT LABELS THAT ARE DEEMED TO BE HOLES.
+
+If your segmentation contains artifacts that cause holes to appear in labels, you can preprocess the entire image to eliminate background holes and holes caused by entirely contained inclusions. This option adds a moderate amount of additional processing time at the beginning (perhaps ~30%). 
 
 #### `progress`
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ skels = kimimaro.skeletonize(
   anisotropy=(16,16,40), # default True
   fix_branching=True, # default True
   fix_borders=True, # default True
+  fill_holes=False, # default False
   progress=True, # default False, show progress bar
   parallel=1, # <= 0 all cpu, 1 single process, 2+ multiprocess
   parallel_chunk_size=100, # how many skeletons to process before updating progress bar
@@ -151,6 +152,10 @@ This feature makes it easier to connect the skeletons of adjacent image volumes 
 #### `fix_branching`  
 
 You'll probably never want to disable this, but base TEASAR is infamous for forking the skeleton at branch points way too early. This option makes it preferential to fork at a more reasonable place at a significant performance penalty. 
+
+#### `fill_holes`
+
+If your segmentation contains artifacts that cause holes to appear in labels, you can preprocess the entire image to eliminate background holes and holes caused by entirely contained inclusions. This option adds a moderate amount of additional processing time at the beginning (perhaps ~30%).
 
 #### `progress`
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -15,13 +15,13 @@ def test_binary_image():
 
   assert len(skels) == 1
 
-
-def test_square():
+@pytest.mark.parametrize('fill_holes', (True, False))
+def test_square(fill_holes):
   labels = np.ones( (1000, 1000), dtype=np.uint8)
   labels[-1,0] = 0
   labels[0,-1] = 0
   
-  skels = kimimaro.skeletonize(labels, fix_borders=False)
+  skels = kimimaro.skeletonize(labels, fix_borders=False, fill_holes=fill_holes)
 
   assert len(skels) == 1
 
@@ -34,7 +34,7 @@ def test_square():
   labels[0,0] = 0
   labels[-1,-1] = 0
 
-  skels = kimimaro.skeletonize(labels, fix_borders=False)
+  skels = kimimaro.skeletonize(labels, fix_borders=False, fill_holes=fill_holes)
 
   assert len(skels) == 1
 

--- a/automated_test.py
+++ b/automated_test.py
@@ -384,3 +384,23 @@ def test_join_close_components_complex():
   assert len(res.components()) == 1
 
   assert np.all(res.edges == [[0,1], [0,3], [1,2], [3,4], [4,5], [5,6], [6,7]])
+
+def test_fill_all_holes():
+  labels = np.zeros((64, 32, 32), dtype=np.uint32)
+
+  labels[0:32,:,:] = 1
+  labels[32:64,:,:] = 8
+
+  noise = np.random.randint(low=1, high=8, size=(30, 30, 30))
+  labels[1:31,1:31,1:31] = noise
+
+  noise = np.random.randint(low=8, high=11, size=(30, 30, 30))
+  labels[33:63,1:31,1:31] = noise
+
+  noise_labels = np.unique(labels)
+  assert set(noise_labels) == set([1,2,3,4,5,6,7,8,9,10])
+
+  result = kimimaro.intake.fill_all_holes(labels)
+
+  filled_labels = np.unique(result)
+  assert set(filled_labels) == set([1,8])

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -87,6 +87,9 @@ def skeletonize(
       components and delete labels that get filled in. This can improve the
       quality of the reconstruction if holes in the shapes are artifacts introduced
       by the segmentation pipeline. This option incurs moderate overhead.
+
+      WARNING: THIS WILL REMOVE INPUT LABELS THAT ARE DEEMED TO BE HOLES.
+
     cc_safety_factor: Value between 0 and 1 that scales the size of the 
       disjoint set maps in connected_components. 1 is guaranteed to work,
       but is probably excessive and corresponds to every pixel being a different
@@ -516,7 +519,7 @@ def synapses_to_targets(labels, synapses, progress=False):
 def fill_all_holes(cc_labels, progress=False, return_fill_count=False):
   """
   Fills the holes in each connected component and removes components that
-  get filled in. The idea is that holes (or even entirely contained labels) 
+  get filled in. The idea is that holes (entirely contained labels or background) 
   are artifacts in cell segmentations. A common example is a nucleus segmented 
   separately from the rest of the cell or errors in a manual segmentation leaving
   a void in a dendrite.

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -54,6 +54,7 @@ def skeletonize(
     progress=False, fix_branching=True, in_place=False, 
     fix_borders=True, parallel=1, parallel_chunk_size=100,
     extra_targets_before=[], extra_targets_after=[],
+    fill_holes=False
   ):
   """
   Skeletonize all non-zero labels in a given 2D or 3D image.
@@ -82,6 +83,10 @@ def skeletonize(
     }
     dust_threshold: don't bother skeletonizing connected components smaller than
       this many voxels.
+    fill_holes: preemptively run a void filling algorithm on all connected
+      components and delete labels that get filled in. This can improve the
+      quality of the reconstruction if holes in the shapes are artifacts introduced
+      by the segmentation pipeline. This option incurs moderate overhead.
     cc_safety_factor: Value between 0 and 1 that scales the size of the 
       disjoint set maps in connected_components. 1 is guaranteed to work,
       but is probably excessive and corresponds to every pixel being a different
@@ -137,6 +142,9 @@ def skeletonize(
 
   cc_labels, remapping = compute_cc_labels(all_labels, cc_safety_factor)
   del all_labels
+
+  if fill_holes:
+    cc_labels = fill_all_holes(cc_labels, progress)
 
   extra_targets_before = points_to_labels(extra_targets_before, cc_labels)
   extra_targets_after = points_to_labels(extra_targets_after, cc_labels)
@@ -504,6 +512,58 @@ def synapses_to_targets(labels, synapses, progress=False):
       targets.update({ target: swc_label for target in tmp_targets })
 
   return targets
+
+def fill_all_holes(cc_labels, progress=False, return_fill_count=False):
+  """
+  Fills the holes in each connected component and removes components that
+  get filled in. The idea is that holes (or even entirely contained labels) 
+  are artifacts in cell segmentations. A common example is a nucleus segmented 
+  separately from the rest of the cell or errors in a manual segmentation leaving
+  a void in a denrite.
+
+  cc_labels: an image containing connected components with labels smaller than
+    the number of voxels in the image.
+  progress: Display a progress bar or not.
+  return_fill_count: if specified, return a tuple (filled_image, N) where N is
+    the number of voxels that were filled in.
+
+  Returns: filled_in_labels
+
+  """
+  import fill_voids
+
+  labels = fastremap.unique(cc_labels)
+  labels_set = set(labels)
+  labels_set.discard(0)
+
+  all_slices = find_objects(cc_labels)
+  pixels_filled = 0
+
+  for label in tqdm(labels, disable=(not progress), desc="Filling Holes"):
+    if label not in labels_set:
+      continue
+
+    slices = all_slices[label - 1]
+    if slices is None:
+      continue
+
+    binary_image = (cc_labels[slices] == label)
+    binary_image, N = fill_voids.fill(
+      binary_image, in_place=True, 
+      return_fill_count=True
+    )
+    pixels_filled += N
+    if N == 0:
+      continue 
+
+    sub_labels = set(fastremap.unique(cc_labels[slices] * binary_image))
+    sub_labels.remove(label)
+    labels_set -= sub_labels
+    cc_labels[slices] = cc_labels[slices] * ~binary_image + label * binary_image
+
+  if return_fill_count:
+    return cc_labels, pixels_filled
+  return cc_labels
 
 def print_quotes(parallel):
   if parallel == -1:

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -519,7 +519,7 @@ def fill_all_holes(cc_labels, progress=False, return_fill_count=False):
   get filled in. The idea is that holes (or even entirely contained labels) 
   are artifacts in cell segmentations. A common example is a nucleus segmented 
   separately from the rest of the cell or errors in a manual segmentation leaving
-  a void in a denrite.
+  a void in a dendrite.
 
   cc_labels: an image containing connected components with labels smaller than
     the number of voxels in the image.
@@ -528,7 +528,6 @@ def fill_all_holes(cc_labels, progress=False, return_fill_count=False):
     the number of voxels that were filled in.
 
   Returns: filled_in_labels
-
   """
   import fill_voids
 


### PR DESCRIPTION
Fills the holes in each connected component and removes components that
get filled in. The idea is that holes (or even entirely contained labels) 
are artifacts in cell segmentations. A common example is a nucleus segmented 
separately from the rest of the cell or errors in a manual segmentation leaving
a void in a dendrite.

This option should be very helpful for newbies to skeletonization. I've interacted with one or two researchers that were getting bad results and on inspection had holes in their segmentation. If this option was default on, it might make the package more intuitive. 

On my standard 512x512x512 test volume, this option took about 1m40s to run. On the upside, it should save somata from needing a recalculated EDT (they were already getting their holes filled, but after the EDT was calculated).
