### PR TITLE
fix(intake): solid color blocks were causing errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,16 @@
 language: python
 python:
-- '2.7'
 - '3.5'
 - '3.6'
 - '3.7'
 - '3.8'
 before_install:
 - PYTHON_MAJOR_VERSION=`echo $TRAVIS_PYTHON_VERSION | head -c 1`
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then sudo apt-get install python3-pip; fi
+- sudo apt-get install python3-pip
 install:
-- if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then virtualenv venv; fi
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then virtualenv -p python3 venv; fi
+- virtualenv -p python3 venv
 - source venv/bin/activate
-- if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then pip install numpy; fi
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then pip3 install numpy; fi
-- if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then pip install -e .; fi
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then pip3 install -e .; fi
+- pip3 install numpy
+- pip3 install -e .
 script:
-- if [[ $PYTHON_MAJOR_VERSION == 2 ]]; then py.test -v -x automated_test.py; fi 
-- if [[ $PYTHON_MAJOR_VERSION == 3 ]]; then python3 -m pytest -v -x automated_test.py; fi
+- python3 -m pytest -v -x automated_test.py

--- a/automated_test.py
+++ b/automated_test.py
@@ -7,6 +7,18 @@ from cloudvolume import *
 import kimimaro.intake
 import kimimaro.skeletontricks
 
+def test_empty_image():
+  labels = np.zeros( (256, 256, 256), dtype=np.bool)  
+  skels = kimimaro.skeletonize(labels, fix_borders=True)
+
+  assert len(skels) == 0
+
+def test_solid_image():
+  labels = np.ones( (256, 256, 256), dtype=np.bool)  
+  skels = kimimaro.skeletonize(labels, fix_borders=True)
+
+  assert len(skels) == 1
+
 def test_binary_image():
   labels = np.ones( (256, 256, 3), dtype=np.bool)
   labels[-1,0] = 0

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -143,7 +143,9 @@ def skeletonize(
   if all_labels.size <= dust_threshold:
     return {}
   
-  if not np.any(all_labels):
+  minlabel, maxlabel = fastremap.minmax(all_labels)
+
+  if minlabel == 0 and maxlabel == 0:
     return {}
 
   cc_labels, remapping = compute_cc_labels(all_labels, cc_safety_factor)
@@ -158,7 +160,7 @@ def skeletonize(
   def edtfn(labels):
     return edt.edt(labels, 
       anisotropy=anisotropy,
-      black_border=False,
+      black_border=(minlabel == maxlabel),
       order='F',
       parallel=parallel,
     )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
-from distutils.command.build import build
-from subprocess import call
 import os
-import shutil
 import setuptools
 
 import numpy as np
@@ -13,9 +9,7 @@ import numpy as np
 
 setuptools.setup(
   setup_requires=['pbr', 'numpy'],
-  extras_require={
-     ':python_version == "2.7"': ['futures'],
-  },
+  python_requires="~=3.4", # >= 3.4 < 4.0
   ext_modules=[
     setuptools.Extension(
       'kimimaro.skeletontricks',


### PR DESCRIPTION
The DBF was solid inf and was wrecking havoc. We fix this
by using black_border=True when the min and max label match
and are non-zero. Solid zero blocks are caught earlier.