### PR TITLE
perf: use the "railroad" technique

### DIFF
--- a/kimimaro/trace.py
+++ b/kimimaro/trace.py
@@ -224,7 +224,7 @@ def compute_paths(
       DAF.pop(0)
     return target_finder.find_target(labels)
 
-  parents[tuple(root)] = 0
+  parents[tuple(root)] = 0 # provide initial rail for dijkstra.railroad
 
   while (valid_labels > 0 or manual_targets_before or manual_targets_after) \
     and len(paths) < max_paths:

--- a/kimimaro/trace.py
+++ b/kimimaro/trace.py
@@ -237,19 +237,9 @@ def compute_paths(
       target = find_target()
 
     if fix_branching:
-      # faster to trace from target to root than root to target
-      # because that way local exploration finds any zero weighted path
-      # and finishes vs exploring from the neighborhood of the entire zero
-      # weighted path
-      if soma_mode:
-        path = dijkstra3d.dijkstra(
-          parents, target, root, 
-          bidirectional=True, voxel_graph=voxel_graph
-        )
-      else:
-        path = dijkstra3d.railroad(
-          parents, target, voxel_graph=voxel_graph
-        )
+      path = dijkstra3d.railroad(
+        parents, target, voxel_graph=voxel_graph
+      )
     else:
       path = dijkstra3d.path_from_parents(parents, target)
     

--- a/kimimaro/trace.py
+++ b/kimimaro/trace.py
@@ -224,6 +224,8 @@ def compute_paths(
       DAF.pop(0)
     return target_finder.find_target(labels)
 
+  parents[tuple(root)] = 0
+
   while (valid_labels > 0 or manual_targets_before or manual_targets_after) \
     and len(paths) < max_paths:
 
@@ -239,10 +241,15 @@ def compute_paths(
       # because that way local exploration finds any zero weighted path
       # and finishes vs exploring from the neighborhood of the entire zero
       # weighted path
-      path = dijkstra3d.dijkstra(
-        parents, target, root, 
-        bidirectional=soma_mode, voxel_graph=voxel_graph
-      )
+      if soma_mode:
+        path = dijkstra3d.dijkstra(
+          parents, target, root, 
+          bidirectional=True, voxel_graph=voxel_graph
+        )
+      else:
+        path = dijkstra3d.railroad(
+          parents, target, voxel_graph=voxel_graph
+        )
     else:
       path = dijkstra3d.path_from_parents(parents, target)
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 connected-components-3d>=1.5.0
 cloud-volume>=0.57.6
-dijkstra3d>=1.11.0
+dijkstra3d>=1.12.0
 fill-voids>=2.0.0
 edt>=2.1.0
 fastremap>=1.10.2


### PR DESCRIPTION
A "rail road" (a term defined by us) is the shortest last-mile path (the "road") from a target point to a "rail network" that includes the source point. A "rail" is a zero weighted path that acts as a strong attractor for the search algorithm. In the context of the 
skeletonization problem, such networks are assembled as a matter of course. It becomes more and more efficient to search for the rail network than for the target point.

For example, consider a glia. As the number of paths increases, the size of the rail network grows to the point that a source->target algorithm will perform extraneous work searching the network even though it is already a restricted domain compared to a naive search. Instead, it makes more sense to find the first rail, which generates a shorter path and avoids the extraneous work.

The shorter path also reduces redundancy in the invalidation algorithm as otherwise the same voxels need to be invalidated over and over (though there is already a provision for preventing that issue).
