### PR TITLE
call kimimaro.skeletontricks.roll_invalidation_ball_inside_component using positional-only arguments

### DIFF
--- a/kimimaro/trace.py
+++ b/kimimaro/trace.py
@@ -160,10 +160,10 @@ def trace(
   if soma_mode:
     invalidated, labels = kimimaro.skeletontricks.roll_invalidation_ball_inside_component(
       labels, DBF, 
-      path=[root],
-      scale=soma_invalidation_scale,
-      const=soma_invalidation_const, 
-      anisotropy=anisotropy,
+      soma_invalidation_scale,
+      soma_invalidation_const, 
+      anisotropy,
+      [root],
       voxel_connectivity_graph=voxel_graph,
     )
   # This target is only valid if no 
@@ -261,7 +261,7 @@ def compute_paths(
     if valid_labels > 0:
       invalidated, labels = kimimaro.skeletontricks.roll_invalidation_ball_inside_component(
         labels, DBF, scale, const, 
-        anisotropy=anisotropy, path=path,
+        anisotropy, path,
         voxel_connectivity_graph=voxel_graph,
       )      
       valid_labels -= invalidated


### PR DESCRIPTION
https://github.com/seung-lab/kimimaro/blob/c9e58f677d522d7b7f3c72c75d9fa768bb5e5e71/ext/skeletontricks/skeletontricks.pyx#L372
https://stackoverflow.com/questions/68380123/cythonized-function-with-a-single-positional-argument-is-not-possible-to-call-us

Cython by default does not allow positional arguments to be specified in a kwargs-like style. This fix stops `kimimaro.skeletonize` from raising `TypeError: roll _invalidation_ball_inside_component() takes at least 6 positional arguments`, which is introduced in https://github.com/seung-lab/kimimaro/pull/86