### PR TITLE
perf+feat: allow input of CrackleArray for lower memory usage

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         arch: [auto]
         include:
           - os: ubuntu-latest

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -520,6 +520,13 @@ def apply_object_mask(all_labels, object_ids):
   if object_ids is None:
     return all_labels
 
+  if isinstance(all_labels, CrackleArray):
+    mask = all_labels.labels()
+    mask = { u: 0 for u in mask }
+    for segid in object_ids:
+      mask[segid] = segid
+    return all_labels.remap(mask).condense()
+
   if len(object_ids) == 1:
     all_labels = kimimaro.skeletontricks.zero_out_all_except(all_labels, object_ids[0]) # faster
   else:

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -259,7 +259,7 @@ def skeletonize(
       cc_mmap.close()
       shm.unlink(dbf_shm_location)
       shm.unlink(cc_shm_location)
-      if vg_mmap:
+      if vg_mmap is not None:
         vg_mmap.close()
         shm.unlink(vg_shm_location)
 

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -462,7 +462,7 @@ def skeletonize_subset(
         labels = cc_labels[slices]
         labels = (labels == segid)
 
-      dbf = (labels * all_dbf[slices]).astype(np.float32, copy=False)
+      dbf = np.where(labels, all_dbf[slices], 0.0)
       cropped_voxel_graph = (voxel_graph[slices] if voxel_graph is not None else None)
 
       manual_targets_before = []

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -456,8 +456,9 @@ def skeletonize_subset(
         continue
 
       if isinstance(cc_labels, CrackleArray):
-        labels = cc_labels.decompress(label=segid)
-        labels = np.asfortranarray(labels[slices])
+        labels = cc_labels.decompress(label=segid, crop=True)
+        label_slcs = (slices[0], slices[1], slice(None))
+        labels = np.asfortranarray(labels[label_slcs])
       else:
         labels = cc_labels[slices]
         labels = (labels == segid)

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -235,7 +235,7 @@ def skeletonize(
       del all_dbf 
 
       cc_mmap, cc_labels_shm = shm.ndarray( cc_labels.shape, cc_labels.dtype, cc_shm_location, order='F')    
-      cc_labels_shm[:] = cc_labels 
+      cc_labels_shm[:] = cc_labels[:]
       del cc_labels
 
       voxel_graph_shm = None

--- a/kimimaro/intake.py
+++ b/kimimaro/intake.py
@@ -259,7 +259,7 @@ def skeletonize(
       cc_mmap.close()
       shm.unlink(dbf_shm_location)
       shm.unlink(cc_shm_location)
-      if vg_mmap is not None:
+      if voxel_graph is not None:
         vg_mmap.close()
         shm.unlink(vg_shm_location)
 

--- a/kimimaro/trace.py
+++ b/kimimaro/trace.py
@@ -289,7 +289,7 @@ def find_soma_root(DBF, dbf_max):
   """
   maxima = (DBF == dbf_max)
   com = ndimage.measurements.center_of_mass(maxima)
-  com = np.array(com, dtype=np.float32)
+  com = np.asarray(com, dtype=np.float32)
   
   coords = np.where(maxima)
   coords = np.vstack( coords ).T

--- a/kimimaro/utility.py
+++ b/kimimaro/utility.py
@@ -504,9 +504,12 @@ def cross_sectional_area(
     xs3d.set_shape(all_labels)
     if isinstance(all_labels, CrackleArray):
       bboxes = all_labels.bounding_boxes()
-      for label, binimg in tqdm(all_labels.each(crop=True), disable=(not progress), desc="Cross Section Analysis Paths"):
-        if label not in skeletons:
-          continue
+      iterator = tqdm(
+        all_labels.each(crop=True, labels=list(skeletons.keys())),
+        disable=(not progress),
+        desc="Cross Section Analysis Paths"
+      )
+      for label, binimg in iterator:
         slc = Bbox.from_slices(bboxes[label])
         cross_sectional_area_helper(skeletons[label], binimg, slc)
     else:

--- a/kimimaro/utility.py
+++ b/kimimaro/utility.py
@@ -14,6 +14,7 @@ from osteoid import Skeleton, Bbox, Vec
 import kimimaro.skeletontricks
 
 import cc3d
+from crackle import CrackleArray
 import dijkstra3d
 import fastremap
 import fill_voids
@@ -55,6 +56,16 @@ def extract_skeleton_from_binary_image(image):
   return Skeleton(verts, edges)
 
 def compute_cc_labels(all_labels, voxel_graph = None):
+  if isinstance(all_labels, CrackleArray):
+    if voxel_graph is not None:
+      all_labels = all_labels[:]
+    else:
+      return all_labels.connected_components(
+        connectivity=26,
+        memory_target=int(500e6), 
+        return_mapping=True,
+      )
+
   tmp_labels = all_labels
   if np.dtype(all_labels.dtype).itemsize > 1:
     tmp_labels, remapping = fastremap.renumber(all_labels, in_place=False)
@@ -77,6 +88,13 @@ def find_objects(labels):
   ordered arrays, so we just do it that way and convert
   the results if it's in F order.
   """
+  if isinstance(labels, CrackleArray):
+    bbxes = labels.bounding_boxes()
+    bbxes.pop(0)
+    result = list(bbxes.items())
+    result.sort(key=lambda x: x[0])
+    return [ x[1] for x in result ]
+
   if labels.flags['C_CONTIGUOUS']:
     return scipy.ndimage.find_objects(labels)
   else:

--- a/kimimaro/utility.py
+++ b/kimimaro/utility.py
@@ -502,11 +502,19 @@ def cross_sectional_area(
 
   try:
     xs3d.set_shape(all_labels)
-    shape_iterator(
-      all_labels, skeletons, 
-      fill_holes, in_place, progress, 
-      cross_sectional_area_helper
-    )
+    if isinstance(all_labels, CrackleArray):
+      bboxes = all_labels.bounding_boxes()
+      for label, binimg in tqdm(all_labels.each(crop=True), disable=(not progress), desc="Cross Section Analysis Paths"):
+        if label not in skeletons:
+          continue
+        slc = Bbox.from_slices(bboxes[label])
+        cross_sectional_area_helper(skeletons[label], binimg, slc)
+    else:
+      shape_iterator(
+        all_labels, skeletons, 
+        fill_holes, in_place, progress, 
+        cross_sectional_area_helper
+      )
   finally:
     xs3d.clear_shape()
 

--- a/kimimaro_cli/codecs.py
+++ b/kimimaro_cli/codecs.py
@@ -23,7 +23,7 @@ def load(filename):
 
   if ext == ".ckl":
     import crackle
-    image = crackle.aload(filename)
+    return crackle.aload(filename)
   elif ext == ".npy":
     if filename.endswith(".gz"):
       with gzip.GzipFile(filename, "rb") as f:

--- a/kimimaro_cli/codecs.py
+++ b/kimimaro_cli/codecs.py
@@ -23,7 +23,7 @@ def load(filename):
 
   if ext == ".ckl":
     import crackle
-    image = crackle.load(filename)
+    image = crackle.aload(filename)
   elif ext == ".npy":
     if filename.endswith(".gz"):
       with gzip.GzipFile(filename, "rb") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,20 +87,15 @@ nii = [
 nrrd = [
     "pynrrd",
 ]
-ckl = [
-    "crackle-codec",
-]
 all_formats = [
     "tifffile",
     "nibabel",
     "pynrrd",
-    "crackle-codec",
 ]
 all = [ 
     "tifffile",
     "nibabel",
     "pynrrd",
-    "crackle-codec",
     "microviewer",
     "vtk",
     "pykdtree",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kimimaro"
-version = "5.3.0"
+version = "5.4.0"
 authors = [
     {name = "William Silversmith", email = "ws9@princeton.edu"},
     {name = "Alex Bae"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click
 connected-components-3d>=3.16.0
+crackle-codec>=0.33.0
 dijkstra3d>=1.15.0
 fill-voids>=2.0.0
 edt>=3.0.0


### PR DESCRIPTION
Crackle is an extremely compressed representation for segmentation (hundreds to thousands of times) while still providing access to various functions, such as connected components and decoding to binary images rapidly.

If we provide a CrackleArray instead of a numpy array for the initial input to Kimimaro, we can shrink the memory usage of the input labels and (most of the time) the cc_labels, to near-zero.

https://github.com/seung-lab/crackle

This update also include a small general performance improvement for extracting the dbf for each segment.