### PR TITLE
fix: roll_invalidation_cube anisotropic weights bug

### DIFF
--- a/automated_test.py
+++ b/automated_test.py
@@ -629,6 +629,147 @@ def test_postprocess():
 
   assert Skeleton.equivalent(res_skel, ans)
 
+def _zeroed_set(arr):
+    return set(map(tuple, np.argwhere(arr == 0).tolist()))
 
 
+def _expected_corner_cube(coord, radius, shape, anisotropy=(1.0, 1.0, 1.0)):
+    # lo = max(0, int(coord[i] - radius / w[i]))
+    # hi = min(shape[i] - 1, int(0.5 + coord[i] + radius / w[i]))
+    bbox = []
+    for i in range(3):
+        lo = max(0, int(coord[i] - radius / anisotropy[i]))
+        hi = min(shape[i] - 1, int(0.5 + coord[i] + radius / anisotropy[i]))
+        bbox.append((lo, hi))
+    return {
+        (a, b, c)
+        for a in range(bbox[0][0], bbox[0][1] + 1)
+        for b in range(bbox[1][0], bbox[1][1] + 1)
+        for c in range(bbox[2][0], bbox[2][1] + 1)
+    }
 
+
+def test_roll_invalidation_cube_cubic_isotropic():
+    # Confirm the previously-working cubic+isotropic case still works.
+    labels = np.ones((10, 10, 10), dtype=np.uint8)
+    dbf = np.zeros((10, 10, 10), dtype=np.float32)
+    path = [(5, 5, 5)]
+
+    count, labels_out = kimimaro.skeletontricks.roll_invalidation_cube(
+        labels, dbf, path, 0.0, 2.0, anisotropy=(1.0, 1.0, 1.0),
+    )
+
+    expected = _expected_corner_cube((5, 5, 5), 2.0, (10, 10, 10), (1.0, 1.0, 1.0))
+    assert count == len(expected) == 125
+    assert _zeroed_set(labels_out) == expected
+
+
+def test_roll_invalidation_cube_asymmetric_volume():
+    # Pre-layout-fix this volume's output was scrambled by the C-vs-F
+    # contiguity mismatch in the Cython wrapper.
+    labels = np.ones((3, 4, 5), dtype=np.uint8)
+    dbf = np.zeros((3, 4, 5), dtype=np.float32)
+    path = [(2, 3, 4)]
+
+    count, labels_out = kimimaro.skeletontricks.roll_invalidation_cube(
+        labels, dbf, path, 0.0, 1.0, anisotropy=(1.0, 1.0, 1.0),
+    )
+
+    expected = {
+        (1, 2, 3), (1, 2, 4), (1, 3, 3), (1, 3, 4),
+        (2, 2, 3), (2, 2, 4), (2, 3, 3), (2, 3, 4),
+    }
+    assert count == 8
+    assert _zeroed_set(labels_out) == expected
+
+
+def test_roll_invalidation_cube_anisotropic_axis_ordering():
+    # Pre-layout-fix the cube was rotated 90 degrees on anisotropic input:
+    # the spread that should be widest on numpy axis 0 (smallest weight)
+    # appeared widest on axis 2 instead.
+    labels = np.ones((10, 10, 10), dtype=np.uint8)
+    dbf = np.zeros((10, 10, 10), dtype=np.float32)
+    path = [(5, 5, 5)]
+    anisotropy = (1.0, 2.0, 4.0)
+
+    count, labels_out = kimimaro.skeletontricks.roll_invalidation_cube(
+        labels, dbf, path, 0.0, 3.0, anisotropy=anisotropy,
+    )
+
+    zeroed = _zeroed_set(labels_out)
+    axis_widths = [
+        max(c[i] for c in zeroed) - min(c[i] for c in zeroed) + 1
+        for i in range(3)
+    ]
+    # Lowest weight -> widest spread; highest weight -> narrowest.
+    assert axis_widths[0] >= axis_widths[1] >= axis_widths[2]
+
+
+def test_roll_invalidation_cube_degenerate_x_bbox():
+    # Pre-degenerate-bbox-fix, a single path voxel with r/wx < 0.5
+    # produced 0 invalidations because the topology trick's +1/-1
+    # cancelled at minx == maxx.
+    labels = np.ones((13, 17, 14), dtype=np.uint8)
+    dbf = np.zeros((13, 17, 14), dtype=np.float32)
+    # r/wx_post_layout_patch = 0.965 / 2.58 = 0.374, so minx == maxx == 0.
+    # bbox is 1 (x) * 3 (y, [14..16]) * 3 (z, [0..2]) = 9 cells.
+    path = [(1, 16, 0)]
+
+    count, _ = kimimaro.skeletontricks.roll_invalidation_cube(
+        labels, dbf, path, 0.0, 0.965, anisotropy=(0.94, 0.93, 2.58),
+    )
+    assert count == 9
+
+
+def test_roll_invalidation_cube_random_fixtures():
+    # 100 random fixtures. Compared against the geometric 
+    # bbox formula directly.
+    rng = np.random.default_rng(seed=0xDECAFBAD)
+    mismatches = []
+
+    for trial in range(100):
+        shape = tuple(int(s) for s in rng.integers(8, 24, size=3))
+        labels = np.ones(shape, dtype=np.uint8)
+        dbf = np.zeros(shape, dtype=np.float32)
+        n_path = int(rng.integers(1, 4))
+        path = [
+            tuple(int(rng.integers(0, s)) for s in shape)
+            for _ in range(n_path)
+        ]
+        radius = float(rng.uniform(0.5, 3.0))
+        anisotropy = tuple(float(rng.uniform(0.5, 4.0)) for _ in range(3))
+
+        count, labels_out = kimimaro.skeletontricks.roll_invalidation_cube(
+            labels.copy(), dbf, path, 0.0, radius, anisotropy=anisotropy,
+        )
+
+        expected = set()
+        for coord in path:
+            expected |= _expected_corner_cube(coord, radius, shape, anisotropy)
+
+        actual = _zeroed_set(labels_out)
+        if actual != expected or count != len(expected):
+            mismatches.append({
+                "trial": trial, "shape": shape, "path": path,
+                "radius": radius, "aniso": anisotropy,
+                "count_returned": count, "count_expected": len(expected),
+                "missing_voxels": sorted(expected - actual)[:5],
+                "extra_voxels": sorted(actual - expected)[:5],
+            })
+
+    assert not mismatches, (
+        f"{len(mismatches)}/100 random fixtures disagree with geometric "
+        f"reference. First: {mismatches[0]}"
+    )
+
+
+def test_roll_invalidation_ball_unaffected():
+    # Cofirm the ball variant was never touched by either patch.
+    labels = np.ones((3, 4, 5), dtype=np.uint8)
+    dbf = np.zeros((3, 4, 5), dtype=np.float32)
+    path = [(2, 3, 4)]
+
+    count, _ = kimimaro.skeletontricks.roll_invalidation_ball(
+        labels, dbf, path, 0.0, 1.0, anisotropy=(1.0, 1.0, 1.0),
+    )
+    assert count >= 0

--- a/automated_test.py
+++ b/automated_test.py
@@ -632,7 +632,6 @@ def test_postprocess():
 def _zeroed_set(arr):
     return set(map(tuple, np.argwhere(arr == 0).tolist()))
 
-
 def _expected_corner_cube(coord, radius, shape, anisotropy=(1.0, 1.0, 1.0)):
     # lo = max(0, int(coord[i] - radius / w[i]))
     # hi = min(shape[i] - 1, int(0.5 + coord[i] + radius / w[i]))
@@ -648,9 +647,8 @@ def _expected_corner_cube(coord, radius, shape, anisotropy=(1.0, 1.0, 1.0)):
         for c in range(bbox[2][0], bbox[2][1] + 1)
     }
 
-
 def test_roll_invalidation_cube_cubic_isotropic():
-    # Confirm the previously-working cubic+isotropic case still works.
+    # Confirm cubic+isotropic case.
     labels = np.ones((10, 10, 10), dtype=np.uint8)
     dbf = np.zeros((10, 10, 10), dtype=np.float32)
     path = [(5, 5, 5)]
@@ -663,10 +661,7 @@ def test_roll_invalidation_cube_cubic_isotropic():
     assert count == len(expected) == 125
     assert _zeroed_set(labels_out) == expected
 
-
 def test_roll_invalidation_cube_asymmetric_volume():
-    # Pre-layout-fix this volume's output was scrambled by the C-vs-F
-    # contiguity mismatch in the Cython wrapper.
     labels = np.ones((3, 4, 5), dtype=np.uint8)
     dbf = np.zeros((3, 4, 5), dtype=np.float32)
     path = [(2, 3, 4)]
@@ -682,11 +677,7 @@ def test_roll_invalidation_cube_asymmetric_volume():
     assert count == 8
     assert _zeroed_set(labels_out) == expected
 
-
 def test_roll_invalidation_cube_anisotropic_axis_ordering():
-    # Pre-layout-fix the cube was rotated 90 degrees on anisotropic input:
-    # the spread that should be widest on numpy axis 0 (smallest weight)
-    # appeared widest on axis 2 instead.
     labels = np.ones((10, 10, 10), dtype=np.uint8)
     dbf = np.zeros((10, 10, 10), dtype=np.float32)
     path = [(5, 5, 5)]
@@ -704,11 +695,7 @@ def test_roll_invalidation_cube_anisotropic_axis_ordering():
     # Lowest weight -> widest spread; highest weight -> narrowest.
     assert axis_widths[0] >= axis_widths[1] >= axis_widths[2]
 
-
 def test_roll_invalidation_cube_degenerate_x_bbox():
-    # Pre-degenerate-bbox-fix, a single path voxel with r/wx < 0.5
-    # produced 0 invalidations because the topology trick's +1/-1
-    # cancelled at minx == maxx.
     labels = np.ones((13, 17, 14), dtype=np.uint8)
     dbf = np.zeros((13, 17, 14), dtype=np.float32)
     # r/wx_post_layout_patch = 0.965 / 2.58 = 0.374, so minx == maxx == 0.
@@ -720,10 +707,7 @@ def test_roll_invalidation_cube_degenerate_x_bbox():
     )
     assert count == 9
 
-
 def test_roll_invalidation_cube_random_fixtures():
-    # 100 random fixtures. Compared against the geometric 
-    # bbox formula directly.
     rng = np.random.default_rng(seed=0xDECAFBAD)
     mismatches = []
 
@@ -762,14 +746,80 @@ def test_roll_invalidation_cube_random_fixtures():
         f"reference. First: {mismatches[0]}"
     )
 
+def _make_inputs(shape, seed, order):
+    rng = np.random.default_rng(seed)
+    L = np.ones(shape, dtype=np.uint8)
+    D = rng.uniform(0.8, 2.5, size=shape).astype(np.float32)
+    if order == 'C':
+        return np.ascontiguousarray(L), np.ascontiguousarray(D)
+    return np.asfortranarray(L), np.asfortranarray(D)
 
-def test_roll_invalidation_ball_unaffected():
-    # Cofirm the ball variant was never touched by either patch.
-    labels = np.ones((3, 4, 5), dtype=np.uint8)
-    dbf = np.zeros((3, 4, 5), dtype=np.float32)
-    path = [(2, 3, 4)]
+EQUIV_CASES = [
+    ((8, 8, 8),    [(4, 4, 4)],            (1.0, 1.0, 1.0), 1.0, 0.0, 0),
+    ((8, 8, 8),    [(4, 4, 4)],            (1.0, 2.0, 4.0), 1.0, 0.0, 0),
+    ((10, 12, 14), [(3, 4, 5), (6, 7, 8)], (1.0, 1.0, 1.0), 1.0, 1.0, 1),
+    ((10, 12, 14), [(3, 4, 5), (6, 7, 8)], (2.0, 1.0, 0.5), 1.5, 0.5, 1),
+    ((16, 8, 4),   [(8, 4, 2)],            (1.0, 1.0, 1.0), 1.0, 0.5, 3),
+    ((4, 8, 16),   [(2, 4, 8)],            (1.0, 1.0, 1.0), 1.0, 0.5, 4),
+    ((10, 10, 10), [(0, 0, 0), (9, 9, 9)], (1.0, 1.0, 1.0), 1.0, 1.0, 5),
+]
 
-    count, _ = kimimaro.skeletontricks.roll_invalidation_ball(
-        labels, dbf, path, 0.0, 1.0, anisotropy=(1.0, 1.0, 1.0),
-    )
-    assert count >= 0
+@pytest.mark.parametrize("shape,path,aniso,scale,const,seed", EQUIV_CASES)
+def test_c_and_f_produce_same_logical_result(shape, path, aniso, scale, const, seed):
+    L_c, D_c = _make_inputs(shape, seed, 'C')
+    L_f, D_f = _make_inputs(shape, seed, 'F')
+    assert np.array_equal(L_c, L_f)
+    assert np.array_equal(D_c, D_f)
+
+    inv_c, out_c = kimimaro.skeletontricks.roll_invalidation_cube(L_c, D_c, path, scale, const, aniso)
+    inv_f, out_f = kimimaro.skeletontricks.roll_invalidation_cube(L_f, D_f, path, scale, const, aniso)
+
+    assert inv_c == inv_f, "invalidated count differs between C and F"
+    assert np.array_equal(out_c, out_f), "voxel set differs between C and F"
+
+@pytest.mark.parametrize("order", ['C', 'F'])
+def test_output_preserves_input_layout(order):
+    L, D = _make_inputs((10, 12, 14), seed=0, order=order)
+    _, out = kimimaro.skeletontricks.roll_invalidation_cube(L, D, [(5, 6, 7)], 1.0, 0.5)
+    if order == 'C':
+        assert out.flags.c_contiguous and not out.flags.f_contiguous
+    else:
+        assert out.flags.f_contiguous and not out.flags.c_contiguous
+
+def test_singleton_shape_runs_without_crashing():
+    L = np.ones((1, 1, 1), dtype=np.uint8)
+    D = np.ones((1, 1, 1), dtype=np.float32)
+    assert L.flags.c_contiguous and L.flags.f_contiguous
+    inv, out = kimimaro.skeletontricks.roll_invalidation_cube(L, D, [(0, 0, 0)], 1.0, 1.0)
+    assert int(inv) >= 0
+    assert out is L
+
+@pytest.mark.parametrize("labels_order,dbf_order", [
+    ('C', 'C'), ('C', 'F'), ('F', 'C'), ('F', 'F'),
+])
+def test_dbf_layout_mismatch_is_normalized(labels_order, dbf_order):
+    shape = (10, 12, 14)
+    rng = np.random.default_rng(0)
+    raw_dbf = rng.uniform(0.8, 2.5, size=shape).astype(np.float32)
+    path = [(3, 4, 5), (6, 7, 8)]
+
+    L = np.ones(shape, dtype=np.uint8, order=labels_order)
+    D = (np.asfortranarray(raw_dbf) if dbf_order == 'F'
+         else np.ascontiguousarray(raw_dbf))
+
+    # Caller's DBF must not be mutated.
+    d_id, d_flags, d_data = id(D), (D.flags.c_contiguous, D.flags.f_contiguous), D.copy()
+
+    inv, out = kimimaro.skeletontricks.roll_invalidation_cube(L, D, path, 1.0, 0.5)
+
+    assert id(D) == d_id
+    assert (D.flags.c_contiguous, D.flags.f_contiguous) == d_flags
+    assert np.array_equal(D, d_data), "caller's DBF was mutated"
+
+    # And the result must match the all-aligned baseline.
+    L_ref = np.ones(shape, dtype=np.uint8, order=labels_order)
+    D_ref = (np.asfortranarray(raw_dbf) if labels_order == 'F'
+             else np.ascontiguousarray(raw_dbf))
+    inv_ref, out_ref = kimimaro.skeletontricks.roll_invalidation_cube(L_ref, D_ref, path, 1.0, 0.5)
+    assert inv == inv_ref
+    assert np.array_equal(out, out_ref)

--- a/ext/skeletontricks/skeletontricks.hpp
+++ b/ext/skeletontricks/skeletontricks.hpp
@@ -73,6 +73,9 @@ size_t _roll_invalidation_cube(
   size_t loc;
   float radius;
 
+  // Track invalidation from degenerate-x-bbox path voxels
+  size_t direct_invalidated = 0;
+
   // First pass: compute toplology
   for (size_t i = 0; i < path_size; i++) {
     loc = path[i];
@@ -97,6 +100,22 @@ size_t _roll_invalidation_cube(
     maxy = std::min(sy-1, static_cast<int64_t>(0.5 + (y + (radius / wy))));
     minz = std::max(ZERO,    static_cast<int64_t>(z - (radius / wz)));
     maxz = std::min(sz-1, static_cast<int64_t>(0.5 + (z + (radius / wz))));
+
+    // Bypass topology trick for when minx==maxx, 
+    // which results in +1 and -1 both targeting 
+    // the same cell, and cancelling eachother 
+    // so that Pass 2 sees topology of 0 in that 
+    // cell, and that cell is never invalidated.
+    if (minx == maxx) {
+      for (y = miny; y <= maxy; y++) {
+        for (z = minz; z <= maxz; z++) {
+          const size_t idx = minx + sx * y + sxy * z;
+          direct_invalidated += static_cast<size_t>(labels[idx] > 0);
+          labels[idx] = 0;
+        }
+      }
+      continue;
+    }
 
     global_minx = std::min(global_minx, minx);
     global_maxx = std::max(global_maxx, maxx);
@@ -132,7 +151,7 @@ size_t _roll_invalidation_cube(
     }
   }
 
-  return invalidated;
+  return invalidated + direct_invalidated;
 }
 
 template <typename T>

--- a/ext/skeletontricks/skeletontricks.pyx
+++ b/ext/skeletontricks/skeletontricks.pyx
@@ -776,33 +776,42 @@ def roll_invalidation_cube(
   in a cube around each vertex. In contrast to `roll_invalidation_ball`,
   this function runs in time linear in the number of image pixels.
   """
+
+  cdef size_t invalidated = 0
+  if len(path) == 0:
+      return (invalidated, labels)
+
+  #   C++ x  <->  numpy axis 2  (fast / stride 1)
+  #   C++ z  <->  numpy axis 0  (slow / largest stride)
   cdef int64_t sx, sy, sz 
-  sx = labels.shape[0]
+  sx = labels.shape[2]
   sy = labels.shape[1]
-  sz = labels.shape[2]
+  sz = labels.shape[0]
 
   cdef size_t sxy = sx * sy
 
-  cdef float wx, wy, wz
-  (wx, wy, wz) = anisotropy
-
+  # Path linearization in C-contigous order
   path = [ 
-    coord[0] + sx * coord[1] + sxy * coord[2] 
+    coord[2] + sx * coord[1] + sxy * coord[0] 
     for coord in path if tuple(coord) not in invalid_vertices 
   ]
-  path = np.array(path, dtype=np.uintp)
+  cdef cnp.ndarray[size_t, ndim=1] path_arr = np.asarray(path, dtype=np.uintp)
 
-  cdef size_t[:] pathview = path
+  # Since C++ x maps to numpy axis 2, swap accordingly
+  cdef float wx, wy, wz
+  (wz, wy, wx) = anisotropy
 
-  cdef size_t invalidated = _roll_invalidation_cube(
-    <uint8_t*>&labels[0,0,0], <float*>&DBF[0,0,0],
-    sx, sy, sz, 
-    wx, wy, wz,
-    <size_t*>&pathview[0], path.size,
-    scale, const
-  )
+  invalidated = _roll_invalidation_cube(
+        <uint8_t*>&labels[0,0,0],
+        <float*>&DBF[0,0,0],
+        sx, sy, sz,
+        wx, wy, wz,
+        <size_t*>&path_arr[0],
+        path_arr.size,
+        scale, const,
+    )
 
-  return invalidated, labels
+  return (invalidated, labels)
 
 @cython.boundscheck(False)
 @cython.wraparound(False)  # turn off negative index wrapping for entire function
@@ -1053,6 +1062,3 @@ def extract_edges_from_binary_image(uint8_t[:,:,:] binimg, int connectivity = 26
   int_edges = np.array(int_edges, dtype=np.uint32)
 
   return (vertices, int_edges)
-
-
-

--- a/ext/skeletontricks/skeletontricks.pyx
+++ b/ext/skeletontricks/skeletontricks.pyx
@@ -760,58 +760,80 @@ cdef float distsq(
   return p1x * p1x + p1y * p1y 
 
 @cython.boundscheck(False)
-@cython.wraparound(False)  # turn off negative index wrapping for entire function
+@cython.wraparound(False)
 @cython.nonecheck(False)
 @cython.binding(True)
 def roll_invalidation_cube(
-    cnp.ndarray[uint8_t, cast=True, ndim=3] labels, 
-    cnp.ndarray[float, ndim=3] DBF, 
+    cnp.ndarray[uint8_t, cast=True, ndim=3] labels,
+    cnp.ndarray[float, ndim=3] DBF,
     path, float scale, float const,
     anisotropy=(1,1,1),
     invalid_vertices={},
-  ):
-  """
-  Given an anisotropic binary image, its distance transform, and a path 
-  traversing the binary image, erase the voxels surrounding the path
-  in a cube around each vertex. In contrast to `roll_invalidation_ball`,
-  this function runs in time linear in the number of image pixels.
-  """
+):
+    """
+    Given an anisotropic binary image, its distance transform, and a path
+    traversing the binary image, erase the voxels surrounding the path
+    in a cube around each vertex. In contrast to roll_invalidation_ball,
+    this function runs in time linear in the number of image pixels.
 
-  cdef size_t invalidated = 0
-  if len(path) == 0:
-      return (invalidated, labels)
+    Supports both C- and F-contiguous labels; DBF is coerced to match.
+    Path coordinates and anisotropy are always in numpy-axis order:
+    coord[i] indexes axis i and anisotropy[i] is the weight along
+    axis i, regardless of layout.
 
-  #   C++ x  <->  numpy axis 2  (fast / stride 1)
-  #   C++ z  <->  numpy axis 0  (slow / largest stride)
-  cdef int64_t sx, sy, sz 
-  sx = labels.shape[2]
-  sy = labels.shape[1]
-  sz = labels.shape[0]
+    Raises:
+      ValueError: if labels is neither C- nor F-contiguous.
+    """
+    cdef bint is_f = labels.flags.f_contiguous
+    if not (is_f or labels.flags.c_contiguous):
+        raise ValueError(
+            "roll_invalidation_cube: `labels` must be C- or F-contiguous. "
+            "Got shape=({0}, {1}, {2}), strides=({3}, {4}, {5}).".format(
+                labels.shape[0], labels.shape[1], labels.shape[2],
+                labels.strides[0], labels.strides[1], labels.strides[2],
+            )
+        )
+    
+    if is_f and not DBF.flags.f_contiguous:
+        DBF = np.asfortranarray(DBF)
+    elif (not is_f) and not DBF.flags.c_contiguous:
+        DBF = np.ascontiguousarray(DBF)
 
-  cdef size_t sxy = sx * sy
+    cdef int64_t shape0 = labels.shape[0]
+    cdef int64_t shape1 = labels.shape[1]
+    cdef int64_t shape2 = labels.shape[2]
+    cdef int64_t sx, sy, sz
+    cdef float wx, wy, wz
 
-  # Path linearization in C-contigous order
-  path = [ 
-    coord[2] + sx * coord[1] + sxy * coord[0] 
-    for coord in path if tuple(coord) not in invalid_vertices 
-  ]
-  cdef cnp.ndarray[size_t, ndim=1] path_arr = np.asarray(path, dtype=np.uintp)
+    if is_f:
+        sx, sy, sz = shape0, shape1, shape2
+        wx, wy, wz = anisotropy[0], anisotropy[1], anisotropy[2]
+        # F-order element strides: (1, shape0, shape0*shape1)
+        path = [
+            coord[0] + shape0 * coord[1] + shape0 * shape1 * coord[2]
+            for coord in path if tuple(coord) not in invalid_vertices
+        ]
+    else:
+        sx, sy, sz = shape2, shape1, shape0
+        wx, wy, wz = anisotropy[2], anisotropy[1], anisotropy[0]
+        # C-order element strides: (shape1*shape2, shape2, 1)
+        path = [
+            coord[2] + shape2 * coord[1] + shape2 * shape1 * coord[0]
+            for coord in path if tuple(coord) not in invalid_vertices
+        ]
+    path = np.array(path, dtype=np.uintp)
+    if path.size == 0:
+        return 0, labels
 
-  # Since C++ x maps to numpy axis 2, swap accordingly
-  cdef float wx, wy, wz
-  (wz, wy, wx) = anisotropy
-
-  invalidated = _roll_invalidation_cube(
-        <uint8_t*>&labels[0,0,0],
-        <float*>&DBF[0,0,0],
+    cdef size_t[:] pathview = path
+    cdef size_t invalidated = _roll_invalidation_cube(
+        <uint8_t*>&labels[0,0,0], <float*>&DBF[0,0,0],
         sx, sy, sz,
         wx, wy, wz,
-        <size_t*>&path_arr[0],
-        path_arr.size,
+        <size_t*>&pathview[0], path.size,
         scale, const,
     )
-
-  return (invalidated, labels)
+    return invalidated, labels
 
 @cython.boundscheck(False)
 @cython.wraparound(False)  # turn off negative index wrapping for entire function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "connected-components-3d>=3.16.0",
     "dijkstra3d>=1.15.0",
     "fill-voids>=2.0.0",
-    "edt>=2.1.0",
+    "edt>=3.0.0",
     "fastremap>=1.10.2",
     "networkx",
     "numpy>=1.16.1",


### PR DESCRIPTION
Two correctness fixes for roll_invalidation_cube, plus regression tests.
1. Cython axis ordering (skeletontricks.pyx). The wrapper linearized path coordinates and unpacked anisotropy in Fortran order while passing C-contiguous numpy arrays to the C++. Outputs were rotated 90° on cubic+anisotropic inputs and scrambled on asymmetric volumes. Fix: tell the C++ that the fast (stride-1) axis is labels.shape[2] rather than labels.shape[0], and permute the path linearization and anisotropy unpacking to match. Public API unchanged.
2. Thin x-bbox cancellation (skeletontricks.hpp). When radius / wx was small enough that a path voxel's x-bbox collapsed to width 1 (minx == maxx), pass 1's topology trick wrote +1 and -1 to the same cell. They cancelled, and pass 2's coloring > 0 || topology[idx] != 0 check skipped those cells, dropping the path voxel's entire contribution. Fix: when minx == maxx, zero the bbox cells directly in pass 1 and skip the topology entries.

Tests in automated_tests.py: cubic-isotropic baseline, asymmetric volume hand-listed expectation, anisotropic axis-ordering check, single-path thin-bbox reproducer, and a 100-fixture random sweep against an independent geometric reference.

Please let me know if any questions.